### PR TITLE
change how fetching of movie reviews are done

### DIFF
--- a/backend/sonar-project.properties
+++ b/backend/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=POC-BE
 sonar.projectName=POC-BE
-sonar.host.url = http://192.168.1.4:9000
+sonar.host.url = http://192.168.1.5:9000
 sonar.login= sqp_c51a8514eea5169430e2c861501a93c3b2bf52cd
 sonar.projectVersion=1.0
 sonar.sourceEncoding=UTF-8

--- a/frontend/.scannerwork/report-task.txt
+++ b/frontend/.scannerwork/report-task.txt
@@ -2,5 +2,5 @@ projectKey=POC-FE
 serverUrl=http://localhost:9000
 serverVersion=9.7.0.61563
 dashboardUrl=http://localhost:9000/dashboard?id=POC-FE
-ceTaskId=AYR5tzPBWo3nbCTboMTt
-ceTaskUrl=http://localhost:9000/api/ce/task?id=AYR5tzPBWo3nbCTboMTt
+ceTaskId=AYSYD0lygcO2J3lC8Jj-
+ceTaskUrl=http://localhost:9000/api/ce/task?id=AYSYD0lygcO2J3lC8Jj-

--- a/frontend/src/__test__/pages/Movies.test.tsx
+++ b/frontend/src/__test__/pages/Movies.test.tsx
@@ -65,7 +65,7 @@ describe("<Movies />", () => {
             isLoading: false,
             movies: [],
             selectedMovie: {} as IMovie,
-            selectedMovieReviews: [],
+            reviews: [],
           },
         },
       }

--- a/frontend/src/components/Tables/TableMovies.tsx
+++ b/frontend/src/components/Tables/TableMovies.tsx
@@ -16,13 +16,7 @@ import { showNotification } from "@mantine/notifications";
 import { useCallback, useEffect, useState } from "react";
 import DataTable, { TableColumn } from "react-data-table-component";
 import { useNavigate } from "react-router-dom";
-import {
-  IconArrowDown,
-  IconEdit,
-  IconTrash,
-  IconEye,
-  IconMessageDots,
-} from "@tabler/icons";
+import { IconArrowDown, IconEdit, IconTrash, IconEye } from "@tabler/icons";
 import { useTypedDispatch, useTypedSelector } from "../../hooks/rtk-hooks";
 import {
   IDispatchResponse,
@@ -36,7 +30,6 @@ import {
   addMovie,
   deleteMovieById,
   fetchAllMovies,
-  fetchMovieReviewsById,
   updateMovieById,
 } from "../../features/movie/movieSlice";
 import {
@@ -230,18 +223,6 @@ const TableMovies = () => {
               data-testid="rowViewMovieBtn"
             >
               <IconEye size={14} strokeWidth={2} />
-            </Button>
-          </Tooltip>
-          <Tooltip label="Manage Reviews" withArrow radius="md">
-            <Button
-              radius="md"
-              ml={5}
-              size="xs"
-              color="green"
-              disabled={isLoading}
-              onClick={() => dispatch(fetchMovieReviewsById(row.id))}
-            >
-              <IconMessageDots size={14} strokeWidth={2} />
             </Button>
           </Tooltip>
           <Tooltip label="Edit Movie" withArrow radius="md">

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { AppShell, Container, Navbar } from "@mantine/core";
-import { IconUser, IconMovie, IconUsers } from "@tabler/icons";
+import { IconUser, IconMovie, IconUsers, IconMessageDots } from "@tabler/icons";
 import {
   TableActors,
   TableMovies,
@@ -15,6 +15,7 @@ const Dashboard = () => {
     { link: "/cm/users", label: "Users", icon: IconUser },
     { link: "/cm/actors", label: "Actors", icon: IconUsers },
     { link: "/cm/movies", label: "Movies", icon: IconMovie },
+    { link: "/cm/reviews", label: "Reviews", icon: IconMessageDots },
   ];
   return (
     <AppShell
@@ -60,16 +61,9 @@ const Dashboard = () => {
         <Routes>
           <Route index element={<Navigate to="users" />} />
           <Route path="users" element={<TableUsers />} />
-          <Route
-            path="movies"
-            element={
-              <>
-                <TableMovies />
-                <TableReviews />
-              </>
-            }
-          />
           <Route path="actors" element={<TableActors />} />
+          <Route path="movies" element={<TableMovies />} />
+          <Route path="reviews" element={<TableReviews />} />
         </Routes>
       </Container>
     </AppShell>

--- a/frontend/src/utils/apiCalls.ts
+++ b/frontend/src/utils/apiCalls.ts
@@ -304,16 +304,35 @@ export const apiDeleteActorById = async (
 };
 
 /**
- * Fetch all reviews of a movie
- * @param {string} movieId - the movie id
+ * Fetch all reviews
  * @returns {APICustomResponse<{}>} - a promise of the returned data from the API
  */
-export const apiFetchMovieReviewsById = async (
-  movieId: string
-): Promise<APICustomResponse<{}>> => {
-  const res = await apiRequest<APICustomResponse<{}>>(
-    `/reviews/movie/${movieId}`
-  );
+export const apiFetchAllMovieReviews = async (): Promise<
+  APICustomResponse<{}>
+> => {
+  const res = await apiRequest<APICustomResponse<{}>>(`/reviews`);
+  return res;
+};
+
+/**
+ * Fetch all approved reviews
+ * @returns {APICustomResponse<{}>} - a promise of the returned data from the API
+ */
+export const apiFetchApprovedMovieReviews = async (): Promise<
+  APICustomResponse<{}>
+> => {
+  const res = await apiRequest<APICustomResponse<{}>>(`/reviews/approved`);
+  return res;
+};
+
+/**
+ * Fetch all unapproved reviews
+ * @returns {APICustomResponse<{}>} - a promise of the returned data from the API
+ */
+export const apiFetchUnapprovedMovieReviews = async (): Promise<
+  APICustomResponse<{}>
+> => {
+  const res = await apiRequest<APICustomResponse<{}>>(`/reviews/unapproved`);
   return res;
 };
 

--- a/frontend/src/utils/types.ts
+++ b/frontend/src/utils/types.ts
@@ -69,6 +69,9 @@ export interface IMovieReview {
   movieId: string;
   userId: string;
   userReviewer?: IMovieReviewer;
+  movieReviews?: {
+    title: string;
+  };
 }
 export interface IMovieReviewer {
   id: string;


### PR DESCRIPTION
- Removed fetching reviews by individual movies.
- Added a new dashboard page for movie reviews alone.
- Inside reviews dashboard page, three buttons are added; for fetching all reviews, fetching all approved and unapproved reviews.
- The reviews table will have a search functionality for searching movie title.
- Initially, all unapproved movie reviews are fetched first.
- Scanned all newly added codes with sonarqube. (All passed).